### PR TITLE
Fix pipeline fork routing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,11 +22,11 @@ pool:
   vmImage: ubuntu-latest
 
 stages:
-  - ${{ if or(ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.Reason'], 'PullRequest')) }}:
+  - ${{ if or(ne(variables['Build.SourceBranch'], 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')) }}:
       - template: .azure-pipelines/stages/deploy-preview-stage.yaml
         parameters:
           workingDirectory: $(Build.Repository.LocalPath)
-  - ${{ if and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+  - ${{ if and(eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'PullRequest')) }}:
       - template: .azure-pipelines/stages/deploy-prod-stage.yaml
         parameters:
           workingDirectory: $(Build.Repository.LocalPath)


### PR DESCRIPTION
The production version of the pipeline was expecting a 'master' branch as opposed to 'main'.