### PR TITLE
adds back compatibility section

### DIFF
--- a/content/docs/faq/meta.json
+++ b/content/docs/faq/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "FAQ",
   "icon": "MyIcon",
-  "pages": ["jobs", "salad-app", "your-account", "community", "company"]
+  "pages": ["jobs", "salad-app", "your-account", "compatibility", "community", "company"]
 }


### PR DESCRIPTION
compatibility section was missing in a meta.json causing the articles to be missing, this adds it back in.
