### PR TITLE
Fix typo in Elevated Permissions recommendation

### DIFF
--- a/content/docs/faq/salad-app/what-are-elevated-permissions-and-should-i-enable-them.md
+++ b/content/docs/faq/salad-app/what-are-elevated-permissions-and-should-i-enable-them.md
@@ -13,7 +13,7 @@ when needed, or if it's going to increase your earnings. You can enable this fea
 
 # Should I enable them?
 
-If you run Salad with with older RX 400-500 AMD GPU enabled, we do recommend enabling Elevated Permissions. It also
+If you run Salad with an older RX 400-500 AMD GPU enabled, we do recommend enabling Elevated Permissions. It also
 allows us to automatically enable certain driver settings to boost your earnings by a significant amount. It's also
 possible we may add more workloads in the future that rely on Elevated Permissions, so even if you don't have an AMD GPU
 we still recommend enabling it if required to allow Salad to always run the most profitable workload for your machine.


### PR DESCRIPTION
Corrected a typo in the recommendation for enabling Elevated Permissions for older AMD GPUs.

Thanks for opening a pull request! Here are some tips:

- Review the contributing guidelines and code of conduct.
- Include a description of your changes.
- Ensure the GitHub Actions complete successfully.
- Screenshots of the changes are helpful.
