### PR TITLE
Add RENDER redemption guide

### DIFF
--- a/content/docs/faq/salad-app/what-are-elevated-permissions-and-should-i-enable-them.md
+++ b/content/docs/faq/salad-app/what-are-elevated-permissions-and-should-i-enable-them.md
@@ -13,10 +13,10 @@ when needed, or if it's going to increase your earnings. You can enable this fea
 
 # Should I enable them?
 
-If you run Salad with an older RX 400-500 AMD GPU enabled, we do recommend enabling Elevated Permissions. It also
-allows us to automatically enable certain driver settings to boost your earnings by a significant amount. It's also
-possible we may add more workloads in the future that rely on Elevated Permissions, so even if you don't have an AMD GPU
-we still recommend enabling it if required to allow Salad to always run the most profitable workload for your machine.
+If you run Salad with an older RX 400-500 AMD GPU enabled, we do recommend enabling Elevated Permissions. It also allows
+us to automatically enable certain driver settings to boost your earnings by a significant amount. It's also possible we
+may add more workloads in the future that rely on Elevated Permissions, so even if you don't have an AMD GPU we still
+recommend enabling it if required to allow Salad to always run the most profitable workload for your machine.
 
 ---
 

--- a/content/docs/guides/getting-started/linux-onboarding.mdx
+++ b/content/docs/guides/getting-started/linux-onboarding.mdx
@@ -4,8 +4,8 @@ title: Linux Onboarding
 
 <Callout type="info">
   The Linux build is in early beta testing, and access is thus granted to specific users following a verification of
-  requirements. Users with large machine counts and able to sign a contract to acccess this beta are invited to 
-  contact our support team at support@salad.com.
+  requirements. Users with large machine counts and able to sign a contract to acccess this beta are invited to contact
+  our support team at support@salad.com.
 </Callout>
 
 We currently offer limited (beta) support for Linux installations. We only support a few distributions at this time but

--- a/content/docs/guides/using-salad/salad-app-passkeys.mdx
+++ b/content/docs/guides/using-salad/salad-app-passkeys.mdx
@@ -23,12 +23,13 @@ The only solution to remove passkeys or acccess protected accounts once set up i
 included **backup codes**.
 
 Store your backup codes in a secure, accessible location - ideally using the 3-2-1 backup rule:
+
 - Create 3 copies of the data
 - Use 2 different storage devices
 - Keep 1 of the backup copies off-site
 
-In this instance, it is recommended to store the backup codes on your machine (on the hard drive), on a
-USB key or external hard drive, and one in the cloud or other machine you own.
+In this instance, it is recommended to store the backup codes on your machine (on the hard drive), on a USB key or
+external hard drive, and one in the cloud or other machine you own.
 
 </Callout>
 

--- a/content/docs/rewards/redeeming-your-rewards/how-to-redeem-render-on-salad.mdx
+++ b/content/docs/rewards/redeeming-your-rewards/how-to-redeem-render-on-salad.mdx
@@ -2,7 +2,8 @@
 title: How to Redeem RENDER on Salad
 ---
 
-RENDER is available on the Salad Storefront as an SPL token on Solana. Redeeming it requires a Solana wallet address saved to your account and a RENDER token account on that wallet.
+RENDER is available on the Salad Storefront as an SPL token on Solana. Redeeming it requires a Solana wallet address
+saved to your account and a RENDER token account on that wallet.
 
 ## Step 1: Add a Solana wallet
 
@@ -19,15 +20,19 @@ RENDER is available on the Salad Storefront as an SPL token on Solana. Redeeming
 
 ## Step 2: Set up your RENDER token account
 
-Your wallet needs a RENDER associated token account (ATA) before you redeem. If it does not exist, the redemption fails and the tokens are not delivered.
+Your wallet needs a RENDER associated token account (ATA) before you redeem. If it does not exist, the redemption fails
+and the tokens are not delivered.
 
 **RENDER mint:** `rndrizKT3MK1iimdxRdWabcF7Zg7AR5T4nud4EkHBof`
 
 Create it once per wallet with the Solana CLI:
+
 ```
 spl-token create-account rndrizKT3MK1iimdxRdWabcF7Zg7AR5T4nud4EkHBof
 ```
-The account is also created automatically the first time the wallet receives or swaps into RENDER. The wallet needs a small amount of SOL for rent and the fee, and it must be the same address you save to Salad.
+
+The account is also created automatically the first time the wallet receives or swaps into RENDER. The wallet needs a
+small amount of SOL for rent and the fee, and it must be the same address you save to Salad.
 
 ## Step 3: Redeem
 
@@ -39,4 +44,6 @@ The account is also created automatically the first time the wallet receives or 
 
 ## Step 4: Find your transaction on Solscan
 
-The transaction hash is your Solana transaction signature, included in the confirmation email. Open it, or paste it into solscan.io, to view the transaction. You can also find it in your wallet's activity: select the RENDER transfer and choose View on Solscan.
+The transaction hash is your Solana transaction signature, included in the confirmation email. Open it, or paste it into
+solscan.io, to view the transaction. You can also find it in your wallet's activity: select the RENDER transfer and
+choose View on Solscan.

--- a/content/docs/rewards/redeeming-your-rewards/how-to-redeem-render-on-salad.mdx
+++ b/content/docs/rewards/redeeming-your-rewards/how-to-redeem-render-on-salad.mdx
@@ -1,0 +1,42 @@
+---
+title: How to Redeem RENDER on Salad
+---
+
+RENDER is available on the Salad Storefront as an SPL token on Solana. Redeeming it requires a Solana wallet address saved to your account and a RENDER token account on that wallet.
+
+## Step 1: Add a Solana wallet
+
+1. Go to your [Account Summary](https://salad.com/account/summary).
+2. Add your Solana wallet address.
+
+> **Wallet address warning**
+>
+> No wallet on your account: the redemption fails and your Salad Balance is refunded.
+>
+> Wrong address on your account: your RENDER is sent there, cannot be recovered, and is not refunded.
+>
+> Confirm the address is correct and belongs to you before you redeem.
+
+## Step 2: Set up your RENDER token account
+
+Your wallet needs a RENDER associated token account (ATA) before you redeem. If it does not exist, the redemption fails and the tokens are not delivered.
+
+**RENDER mint:** `rndrizKT3MK1iimdxRdWabcF7Zg7AR5T4nud4EkHBof`
+
+Create it once per wallet with the Solana CLI:
+```
+spl-token create-account rndrizKT3MK1iimdxRdWabcF7Zg7AR5T4nud4EkHBof
+```
+The account is also created automatically the first time the wallet receives or swaps into RENDER. The wallet needs a small amount of SOL for rent and the fee, and it must be the same address you save to Salad.
+
+## Step 3: Redeem
+
+1. Go to the RENDER reward on the Salad Storefront.
+2. Choose your amount. The exchange rate is shown at checkout.
+3. Click Buy Now to redeem with your Salad Balance.
+4. Your RENDER is sent to the wallet address on your account.
+5. You receive a confirmation email with your Solana transaction hash.
+
+## Step 4: Find your transaction on Solscan
+
+The transaction hash is your Solana transaction signature, included in the confirmation email. Open it, or paste it into solscan.io, to view the transaction. You can also find it in your wallet's activity: select the RENDER transfer and choose View on Solscan.

--- a/content/docs/rewards/redeeming-your-rewards/how-to-redeem-render-on-salad.mdx
+++ b/content/docs/rewards/redeeming-your-rewards/how-to-redeem-render-on-salad.mdx
@@ -20,19 +20,19 @@ saved to your account and a RENDER token account on that wallet.
 
 ## Step 2: Set up your RENDER token account
 
-Your wallet needs a RENDER associated token account (ATA) before you redeem. If it does not exist, the redemption fails
-and the tokens are not delivered.
+Your wallet must have a RENDER associated token account (ATA) before you redeem. If it does not exist, the redemption fails. You only need to set this up once per wallet.
 
-**RENDER mint:** `rndrizKT3MK1iimdxRdWabcF7Zg7AR5T4nud4EkHBof`
+**RENDER mint:** rndrizKT3MK1iimdxRdWabcF7Zg7AR5T4nud4EkHBof
 
-Create it once per wallet with the Solana CLI:
+Create it with the Solana CLI:
 
 ```
 spl-token create-account rndrizKT3MK1iimdxRdWabcF7Zg7AR5T4nud4EkHBof
 ```
 
-The account is also created automatically the first time the wallet receives or swaps into RENDER. The wallet needs a
-small amount of SOL for rent and the fee, and it must be the same address you save to Salad.
+The ATA is also created the first time your wallet swaps into or receives RENDER from another source. Creating the account costs a small amount of SOL in rent.
+
+Receiving your redemption costs you nothing. Salad covers the network fee to send your RENDER. You only need SOL in this wallet if you later decide to move or swap your RENDER yourself.
 
 ## Step 3: Redeem
 

--- a/content/docs/rewards/redeeming-your-rewards/meta.json
+++ b/content/docs/rewards/redeeming-your-rewards/meta.json
@@ -25,5 +25,6 @@
     "redeeming-bitskins-gift-cards-on-salad",
     "how-to-redeem-paypal",
     "supported-paypal-countries"
+    "how-to-redeem-render-on-salad"
   ]
 }

--- a/content/docs/rewards/redeeming-your-rewards/meta.json
+++ b/content/docs/rewards/redeeming-your-rewards/meta.json
@@ -24,7 +24,7 @@
     "how-to-redeem-prepaid-mastercards-on-salad",
     "redeeming-bitskins-gift-cards-on-salad",
     "how-to-redeem-paypal",
-    "supported-paypal-countries"
+    "supported-paypal-countries",
     "how-to-redeem-render-on-salad"
   ]
 }

--- a/content/docs/rewards/rewards-faq/supported-visa-mastercard-countries.md
+++ b/content/docs/rewards/rewards-faq/supported-visa-mastercard-countries.md
@@ -2,9 +2,9 @@
 title: Supported Prepaid Visa & Mastercard Countries
 ---
 
-Salad uses a third party provider to source Prepaid Visa and Mastercard rewards. Some countries are not eligible to purchase 
-Prepaid Visa or Mastercard rewards from our vendor. Refer to the list below to understand where Prepaid Visa and Mastercard
-rewards are supported.
+Salad uses a third party provider to source Prepaid Visa and Mastercard rewards. Some countries are not eligible to
+purchase Prepaid Visa or Mastercard rewards from our vendor. Refer to the list below to understand where Prepaid Visa
+and Mastercard rewards are supported.
 
 Note that purchasing these rewards if your country is not listed here may prevent you from receiving the reward.
 


### PR DESCRIPTION
Adds a Kitchen docs guide for redeeming the new RENDER reward.

New page: content/docs/rewards/redeeming-your-rewards/how-to-redeem-render-on-salad.mdx
Covers: adding a Solana wallet, creating the RENDER token account (ATA), redeeming, and finding the transaction on Solscan.

Follow-up commit on this branch will add the page to redeeming-your-rewards/meta.json so it shows in the sidebar.