### PR TITLE
Add FAQ: Can I Move Salad from the C Drive?

### DIFF
--- a/content/docs/faq/salad-app/can-i-move-salad-from-the-c-drive.md
+++ b/content/docs/faq/salad-app/can-i-move-salad-from-the-c-drive.md
@@ -2,8 +2,8 @@
 title: Can I Move Salad from the C Drive?
 ---
 
-No. Salad needs to be installed on your C drive, and there's no supported way to move it. There is no setting in the
-app to change this, and no manual method that we can help you with. This applies to the Salad App itself, the WSL
+No. Salad needs to be installed on your C drive, and there's no supported way to move it. There is no setting in the app
+to change this, and no manual method that we can help you with. This applies to the Salad App itself, the WSL
 environment where container workloads run, and everything else Salad stores on your machine.
 
 ## Why Does Salad Have to Live on the C Drive?
@@ -11,9 +11,9 @@ environment where container workloads run, and everything else Salad stores on y
 Salad isn't just the app you see. It also manages a WSL (Windows Subsystem for Linux) environment where container
 workloads run. You can learn more about that in [What is WSL?](/faq/jobs/what-is-wsl).
 
-Salad sets up, updates, and repairs this environment automatically, and it always does so at a fixed location on your
-C drive. Because Salad manages these files itself, they can't be relocated. The app expects to find them exactly
-where it put them, and will recreate them there whenever it needs to.
+Salad sets up, updates, and repairs this environment automatically, and it always does so at a fixed location on your C
+drive. Because Salad manages these files itself, they can't be relocated. The app expects to find them exactly where it
+put them, and will recreate them there whenever it needs to.
 
 We know C drive space is tight for a lot of Chefs, especially on machines with a smaller SSD as the boot drive.
 Supporting other drives is a common request, and one we're aware of and intend to address one day. However, for now
@@ -35,8 +35,8 @@ Windows itself is often the biggest space hog on the C drive, and its built-in c
 specify them yourself. Here's how to do so:
 
 1. Open **Settings > System > Storage** to see what's actually using your space.
-2. Under **Temporary files**, look for **Previous Windows installation(s)** and **Windows Update Cleanup**. These
-   alone can be tens of GB after a major Windows update.
+2. Under **Temporary files**, look for **Previous Windows installation(s)** and **Windows Update Cleanup**. These alone
+   can be tens of GB after a major Windows update.
 3. Review the list carefully and remove what you don't need.
 
 ### Move Games to Another Drive

--- a/content/docs/faq/salad-app/can-i-move-salad-from-the-c-drive.md
+++ b/content/docs/faq/salad-app/can-i-move-salad-from-the-c-drive.md
@@ -1,0 +1,61 @@
+---
+title: Can I Move Salad from the C Drive?
+---
+
+No. Salad needs to be installed on your C drive, and there's no supported way to move it. There is no setting in the
+app to change this, and no manual method that we can help you with. This applies to the Salad App itself, the WSL
+environment where container workloads run, and everything else Salad stores on your machine.
+
+## Why Does Salad Have to Live on the C Drive?
+
+Salad isn't just the app you see. It also manages a WSL (Windows Subsystem for Linux) environment where container
+workloads run. You can learn more about that in [What is WSL?](/faq/jobs/what-is-wsl).
+
+Salad sets up, updates, and repairs this environment automatically, and it always does so at a fixed location on your
+C drive. Because Salad manages these files itself, they can't be relocated. The app expects to find them exactly
+where it put them, and will recreate them there whenever it needs to.
+
+We know C drive space is tight for a lot of Chefs, especially on machines with a smaller SSD as the boot drive.
+Supporting other drives is a common request, and one we're aware of and intend to address one day. However, for now
+Salad on the C drive is a strict requirement.
+
+---
+
+## How Can I Free Up Space on My C Drive?
+
+If you're concerned about having enough C drive space to spare for Salad, it helps to know your target: container
+workloads need at least 70GB of free storage space. You can find the full requirements in
+[Is My Machine Compatible With Salad?](/faq/compatibility/is-my-machine-compatible-with-salad)
+
+Here are the things most likely to actually make a difference:
+
+### Clean Up Windows System Files
+
+Windows itself is often the biggest space hog on the C drive, and its built-in cleanup tools skip big items unless you
+specify them yourself. Here's how to do so:
+
+1. Open **Settings > System > Storage** to see what's actually using your space.
+2. Under **Temporary files**, look for **Previous Windows installation(s)** and **Windows Update Cleanup**. These
+   alone can be tens of GB after a major Windows update.
+3. Review the list carefully and remove what you don't need.
+
+### Move Games to Another Drive
+
+You don't need to delete anything. If you have a second drive, most game launchers can move installed games without
+redownloading them:
+
+- **Steam**: Right-click a game > **Properties > Installed Files > Move Install Folder**.
+- **Epic, Battle.net, Xbox App**: Each has a similar move or change-location option in the game's settings.
+
+Moving a couple of large games off your C drive is a quick and easy way to reclaim significant storage space.
+
+### Relocate Your Personal Folders
+
+Windows lets you move your Downloads, Videos, and Documents folders to another drive: right-click the folder, select
+**Properties > Location**, and choose a new home. Windows moves the contents for you and everything keeps working as
+normal.
+
+---
+
+If you've cleared space and Salad still reports a storage issue, or you have any other questions, contact
+[Salad Support](/contact).

--- a/content/docs/faq/salad-app/meta.json
+++ b/content/docs/faq/salad-app/meta.json
@@ -15,6 +15,7 @@
     "top-three-salad-questions",
     "how-does-my-machine-earn-salad-balance",
     "temporary-workload-block",
-    "how-salad-selects-coins-to-mine"
+    "how-salad-selects-coins-to-mine",
+    "can-i-move-salad-from-the-c-drive"
   ]
 }

--- a/content/docs/rewards/redeeming-your-rewards/how-to-redeem-render-on-salad.mdx
+++ b/content/docs/rewards/redeeming-your-rewards/how-to-redeem-render-on-salad.mdx
@@ -20,7 +20,8 @@ saved to your account and a RENDER token account on that wallet.
 
 ## Step 2: Set up your RENDER token account
 
-Your wallet must have a RENDER associated token account (ATA) before you redeem. If it does not exist, the redemption fails. You only need to set this up once per wallet.
+Your wallet must have a RENDER associated token account (ATA) before you redeem. If it does not exist, the redemption
+fails. You only need to set this up once per wallet.
 
 **RENDER mint:** rndrizKT3MK1iimdxRdWabcF7Zg7AR5T4nud4EkHBof
 
@@ -30,9 +31,11 @@ Create it with the Solana CLI:
 spl-token create-account rndrizKT3MK1iimdxRdWabcF7Zg7AR5T4nud4EkHBof
 ```
 
-The ATA is also created the first time your wallet swaps into or receives RENDER from another source. Creating the account costs a small amount of SOL in rent.
+The ATA is also created the first time your wallet swaps into or receives RENDER from another source. Creating the
+account costs a small amount of SOL in rent.
 
-Receiving your redemption costs you nothing. Salad covers the network fee to send your RENDER. You only need SOL in this wallet if you later decide to move or swap your RENDER yourself.
+Receiving your redemption costs you nothing. Salad covers the network fee to send your RENDER. You only need SOL in this
+wallet if you later decide to move or swap your RENDER yourself.
 
 ## Step 3: Redeem
 


### PR DESCRIPTION
Adds a new FAQ article, "Can I Move Salad from the C Drive?", under FAQ > Salad App, and registers it in the section's meta.json so it appears in the sidebar.

Content includes:

- States clearly that C drive is a hard requirement with no supported way to move Salad
- Deliberately does not mention any manual workaround
- Includes practical guidance for freeing up C drive space
- Formatted with the repo's Prettier config